### PR TITLE
docs(pr-template): add template from governance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+# 📦 Pull Request
+
+## 🔍 What
+Concise summary of what this PR changes (new feature, fix, docs update, etc.).
+
+## ❓ Why
+Explain the motivation or problem being solved. Link to context if available.
+
+## 📄 Summary of Changes
+- [ ] Code / file changes described clearly
+- [ ] Updated docs, guides, or standards if affected
+- [ ] Structural or naming adjustments explained
+- [ ] Other:
+
+## ⚠️ Risks / Impact
+- Potential side effects or breaking changes?
+- Dependencies on other repos, workflows, or standards?
+
+## 🧪 Testing / Evidence
+- [ ] Builds/lints locally
+- [ ] Verified output correctness
+- [ ] Screenshots/logs/tests included (if relevant)
+
+## 🔗 Related Issue(s)
+- Resolves #
+- Closes #
+- Ref #
+
+## ✅ Checklist Before Merge
+- [ ] CHANGELOG updated
+- [ ] README/docs updated if needed
+- [ ] Governance alignment confirmed
+- [ ] Naming/structure consistent
+- [ ] Commit(s) follow standards
+- [ ] Reviewer(s) assigned
+
+---
+
+> ⚠️ Reminder: This repository enforces AI and structural governance.
+> All changes must comply with:
+> - `/Governance/AI_Assistant.md`
+> - `/Governance/standards.md`


### PR DESCRIPTION
Copies the canonical PR template into .github/pull_request_template.md.

Ensures every PR is created with governance-aligned sections and checks. Source of truth: Governance/Templates/pull_request_template.md.